### PR TITLE
fix: add requirements.txt + minor nits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lightning-flash[image]==0.8.1
+torchmetrics==0.10.3

--- a/train.py
+++ b/train.py
@@ -1,19 +1,19 @@
 from pathlib import Path
 import torch
 import flash
-#from flash.core.data.utils import download_data
 from flash.image import ImageClassificationData, ImageClassifier
 
 # 1. Create the DataModule
 
 images_path = Path("data/katakana")
-train_path = (images_path/'train')
-validation_path = (images_path/'validation')
+train_path = str(images_path/"train")
+validation_path = str(images_path/"validation")
 
 datamodule = ImageClassificationData.from_folders(
     train_folder=train_path,
     val_folder=validation_path,
-    batch_size = 3,
+    batch_size=3,
+    transform_kwargs={"image_size": (196, 196), "mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
 )
 
 # 2. Build the task


### PR DESCRIPTION
PR содержит 3 изменения:
1. Добавил `requirements.txt`, чтобы ставить нужные версии зависимостей
2. Добавил конвертацию путей в строки, т.к. `ImageClassificationData` ожидает строки, а не объекты `Path`
3. Вернул `transform_kwargs`, т.к. они приводят изображения к формату близкому к тому, на котором резнет был предобучен.